### PR TITLE
Performance save - Replace instances of Math.Random with Random.nextD…

### DIFF
--- a/java/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/java/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/java/modules/samples/src/main/java/samples/userguide/StockQuoteClient.java
+++ b/java/modules/samples/src/main/java/samples/userguide/StockQuoteClient.java
@@ -39,7 +39,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URL;
-
+import java.util.Random;
 /**
  * See build.xml for options
  */
@@ -255,7 +255,8 @@ public class StockQuoteClient {
     }
 
     private static double getRandom(double base, double variance, boolean onlyPositive) {
-        double rand = Math.random();
+	Random r = new Random();
+        double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * variance * base * rand))
                 * (onlyPositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/1.2-656977/modules/samples/services/FastStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/scratch/asankha/1.2-656977/modules/samples/services/FastStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/1.2-656977/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/scratch/asankha/1.2-656977/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/1.2-656977/modules/samples/src/main/java/samples/userguide/GenericJMSClient.java
+++ b/scratch/asankha/1.2-656977/modules/samples/src/main/java/samples/userguide/GenericJMSClient.java
@@ -22,6 +22,7 @@ package samples.userguide;
 import org.apache.synapse.transport.jms.JMSConstants;
 import org.apache.synapse.transport.jms.JMSUtils;
 
+import java.util.Random;
 import javax.jms.*;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -133,7 +134,8 @@ public class GenericJMSClient {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/1.2-656977/modules/samples/src/main/java/samples/userguide/StockQuoteClient.java
+++ b/scratch/asankha/1.2-656977/modules/samples/src/main/java/samples/userguide/StockQuoteClient.java
@@ -36,6 +36,7 @@ import org.apache.synapse.util.UUIDGenerator;
 import org.wso2.mercury.util.MercuryClientConstants;
 import samples.common.StockQuoteHandler;
 
+import java.util.Random;
 import java.io.File;
 import java.net.URL;
 
@@ -247,7 +248,8 @@ public class StockQuoteClient {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
                 * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/synapse_incubator/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/scratch/asankha/synapse_incubator/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/synapse_incubator/modules/samples/src/main/java/samples/userguide/GenericJMSClient.java
+++ b/scratch/asankha/synapse_incubator/modules/samples/src/main/java/samples/userguide/GenericJMSClient.java
@@ -18,6 +18,7 @@
  */
 package samples.userguide;
 
+import java.util.Random;
 import javax.jms.*;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -120,7 +121,8 @@ public class GenericJMSClient {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+	Random r = new Random();
+        double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/synapse_incubator/modules/samples/src/main/java/samples/userguide/PlaceOrderClient.java
+++ b/scratch/asankha/synapse_incubator/modules/samples/src/main/java/samples/userguide/PlaceOrderClient.java
@@ -18,6 +18,8 @@
  */
 package samples.userguide;
 
+import java.util.Random;
+
 import org.apache.axiom.om.OMElement;
 import org.apache.axis2.client.Options;
 import org.apache.axis2.client.ServiceClient;
@@ -60,7 +62,8 @@ public class PlaceOrderClient {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+	Random r = new Random();
+        double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/synapse_ws/modules/samples/services/FastStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/scratch/asankha/synapse_ws/modules/samples/services/FastStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -19,6 +19,7 @@
 package samples.services;
 
 import java.util.Date;
+import java.util.Random;
 
 public class GetQuoteResponse {
     String symbol;
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+	Random r = new Random();
+        double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/synapse_ws/modules/samples/services/SecureStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/scratch/asankha/synapse_ws/modules/samples/services/SecureStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/synapse_ws/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/scratch/asankha/synapse_ws/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/synapse_ws/modules/samples/src/main/java/samples/userguide/StockQuoteClient.java
+++ b/scratch/asankha/synapse_ws/modules/samples/src/main/java/samples/userguide/StockQuoteClient.java
@@ -36,6 +36,7 @@ import org.apache.sandesha2.client.SandeshaClientConstants;
 import org.apache.synapse.util.UUIDGenerator;
 import samples.common.StockQuoteHandler;
 
+import java.util.Random;
 import java.net.URL;
 import java.io.File;
 
@@ -229,7 +230,8 @@ public class StockQuoteClient {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+	Random r = new Random();
+        double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
                 * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/synapse_ws/modules/transports/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
+++ b/scratch/asankha/synapse_ws/modules/transports/src/main/java/org/apache/synapse/transport/vfs/VFSTransportListener.java
@@ -352,8 +352,9 @@ public class VFSTransportListener extends AbstractPollingTransportListener {
             } catch (FileSystemException ignore) {}
 
             // compute the unique message ID
-            String messageId = filePath + "_" + fileName +
-                "_" + System.currentTimeMillis() + "_" + (int) Math.random() * 1000;
+            Random rand = new Random();
+	    String messageId = filePath + "_" + fileName +
+                "_" + System.currentTimeMillis() + "_" + (int) rand.nextDouble()  * 1000;
 
             String contentType = entry.getContentType();
             if (!BaseUtils.isValid(contentType)) {

--- a/scratch/asankha/trunk-24FEB2007/modules/samples/services/FastStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/scratch/asankha/trunk-24FEB2007/modules/samples/services/FastStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/asankha/trunk-24FEB2007/modules/samples/services/SecureStockQuoteService1/src/samples/services/GetQuoteResponse.java
+++ b/scratch/asankha/trunk-24FEB2007/modules/samples/services/SecureStockQuoteService1/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/synapse-2.1-versioned/java/modules/samples/services/FastStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/scratch/synapse-2.1-versioned/java/modules/samples/services/FastStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/synapse-2.1-versioned/java/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
+++ b/scratch/synapse-2.1-versioned/java/modules/samples/services/SimpleStockQuoteService/src/samples/services/GetQuoteResponse.java
@@ -18,6 +18,7 @@
  */
 package samples.services;
 
+import java.util.Random;
 import java.util.Date;
 
 public class GetQuoteResponse {
@@ -169,7 +170,8 @@ public class GetQuoteResponse {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/synapse-2.1-versioned/java/modules/samples/src/main/java/samples/userguide/MDDProducer.java
+++ b/scratch/synapse-2.1-versioned/java/modules/samples/src/main/java/samples/userguide/MDDProducer.java
@@ -24,6 +24,7 @@ import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import java.util.Properties;
 import java.io.*;
+import java.util.Random;
 
 public class MDDProducer {
 
@@ -86,7 +87,8 @@ public class MDDProducer {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
             * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }

--- a/scratch/synapse-2.1-versioned/java/modules/samples/src/main/java/samples/userguide/RabbitMQAMQPClient.java
+++ b/scratch/synapse-2.1-versioned/java/modules/samples/src/main/java/samples/userguide/RabbitMQAMQPClient.java
@@ -32,6 +32,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.QueueingConsumer;
 
 import java.io.IOException;
+import java.util.Random;
 
 /**
  * A generic client for RabbitMQ
@@ -124,7 +125,8 @@ public class RabbitMQAMQPClient {
     }
 
     private static double getRandom(double base, double varience, boolean onlypositive) {
-        double rand = Math.random();
+        Random r = new Random();
+	double rand = r.nextDouble();
         return (base + ((rand > 0.5 ? 1 : -1) * varience * base * rand))
                 * (onlypositive ? 1 : (rand > 0.5 ? 1 : -1));
     }


### PR DESCRIPTION
…ouble

[SYNAPSE-1102](https://issues.apache.org/jira/browse/SYNAPSE-1102) Performance save - Replace instances of Math.Random with Random.nextDouble. Some slight performance can be saved when replacing Math.random with Random.nextDouble, due to Math.random not having to create an instance of Random.