### PR TITLE
SYNAPSE-1109: copy wsa:From value when creating request context

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/util/MessageHelper.java
+++ b/modules/core/src/main/java/org/apache/synapse/util/MessageHelper.java
@@ -238,6 +238,7 @@ public class MessageHelper {
         // do not copy options from the original
         newMC.setConfigurationContext(ori.getConfigurationContext());
         newMC.setMessageID(UIDGenerator.generateURNString());
+        newMC.setFrom(ori.getFrom());
         newMC.setTo(ori.getTo());
         newMC.setSoapAction(ori.getSoapAction());
 

--- a/modules/core/src/test/java/org/apache/synapse/util/MessageHelperTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/util/MessageHelperTest.java
@@ -47,4 +47,15 @@ public class MessageHelperTest extends TestCase {
         assertNotNull(dh);
         assertEquals("test", dh.getContent());
     }
+
+    // Test for SYNAPSE-1109
+    public void testClonePartiallyWithFrom() throws Exception {
+        String fromValue = "uri://some-from-value";
+        MessageContext origMc = new MessageContext();
+        origMc.setFrom(fromValue);
+        MessageContext newMc = MessageHelper.clonePartially(origMc);
+        Object result = newMc.getFrom();
+        assertEquals(fromValue, result);
+    }
+
 }


### PR DESCRIPTION
When a From value is set in the message context (e.g. with MessageContext.setFrom) before it is sent to an endpoint the value isn't used in the resulting request. This is due to the fact that the Axis2FlexibleMEPClient clones the message context before sending it and the MessageHelper.clonePartially doesn't copy the From value from the source message context to the cloned message context.