### PR TITLE
Notify observers when engaging proxy modules

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
@@ -593,8 +593,7 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
         if (wsAddrEnabled) {
             auditInfo("WS-Addressing is enabled for service : " + name);
             try {
-                proxyService.engageModule(axisCfg.getModule(
-                    SynapseConstants.ADDRESSING_MODULE_NAME), axisCfg);
+                proxyService.engageModule(axisCfg.getModule(SynapseConstants.ADDRESSING_MODULE_NAME));
             } catch (AxisFault axisFault) {
                 handleException("Error loading WS Addressing module on proxy service : " + name, axisFault);
             }
@@ -604,8 +603,7 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
         if (wsSecEnabled) {
             auditInfo("WS-Security is enabled for service : " + name);
             try {
-                proxyService.engageModule(axisCfg.getModule(
-                    SynapseConstants.SECURITY_MODULE_NAME), axisCfg);
+                proxyService.engageModule(axisCfg.getModule(SynapseConstants.SECURITY_MODULE_NAME));
             } catch (AxisFault axisFault) {
                 handleException("Error loading WS Sec module on proxy service : "
                         + name, axisFault);


### PR DESCRIPTION
When the addressing or security module is engaged on the proxy service
the Axis2 Observers aren't notified. This is due to the fact that the
wrong engageModule method is invoked on the AxisService.

By invoking the correct engageModule method on the AxisService the Axis2
Observers are notified when a module is engaged on a proxy service.