### PR TITLE
Notify observers when starting proxy services

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/ProxyService.java
@@ -577,7 +577,6 @@ public class ProxyService implements AspectConfigurable, SynapseArtifact {
                     axisCfg.addServiceToExistingServiceGroup(proxyService, serviceGroup);
                 }
             }
-            this.setRunning(true);
         } catch (AxisFault axisFault) {
             try {
                 if (axisCfg.getService(proxyService.getName()) != null) {


### PR DESCRIPTION
When a proxy service is started the Axis2 Observers aren't notified.
This is due to the fact that the proxy services are only loaded by the
Axis2 Synapse controller and not started. Inline in, out and fault
sequences are not initialized, since that happens when a service is
started.

By starting the proxy services explicitly in the Axis2 Synapse
controller the sequences are properly initialized and the Axis2
Observers are notified.