### PR TITLE
Fix SYNAPSE-1105

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/TargetConnections.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/connections/TargetConnections.java
@@ -98,9 +98,10 @@ public class TargetConnections {
                 log.warn("Connection pool reached maximum allowed connections for: "
                         + host + ":" + port + ". Target server may have become slow");
             }
+        } else {
+            return connection;
         }
-
-        return connection;
+        return null;
     }
 
     /**


### PR DESCRIPTION
TargetConnections getConnection method doesn't retrun null when the connection is not available.