### PR TITLE
Fix SYNAPSE-1106

### DIFF
--- a/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
+++ b/modules/transports/core/nhttp/src/main/java/org/apache/synapse/transport/passthru/ClientWorker.java
@@ -234,6 +234,8 @@ public class ClientWorker implements Runnable {
             log.error("Fault creating response SOAP envelope", af);            
         } catch (IOException e) {
             log.error("Error closing input stream from which message was read", e);
+        } finally {
+            cleanup();
         }
     }
 
@@ -251,6 +253,14 @@ public class ClientWorker implements Runnable {
         }
         // Unable to determine the content type - Return default value
         return PassThroughConstants.DEFAULT_CONTENT_TYPE;
+    }
+
+    /**
+     * Perform cleanup of ClientWorker
+     */
+    private void cleanup () {
+        //clean threadLocal variables
+        responseMsgCtx.destroyCurrentMessageContext();
     }
 
 }


### PR DESCRIPTION
MessageContext class store messageContext object in a ThreadLocalVariable where it doesn't clear created ThreadLocal variables properly. Therefore synapse passthrough threads contain created the Theadlocal variable which refers to the created soap envelope during the mediation level. Because of the retained ThreadLocal variables, Passthrough threads consumes a huge amount of memory which leads to OOM.