### PR TITLE
Add an improvement to log-mediator

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/Axis2SynapseController.java
+++ b/modules/core/src/main/java/org/apache/synapse/Axis2SynapseController.java
@@ -108,8 +108,6 @@ public class Axis2SynapseController implements SynapseController {
 
     private TaskScheduler taskScheduler;
 
-    private boolean synapseDebugMode;
-
     /**
      * {@inheritDoc}
      *
@@ -1015,13 +1013,5 @@ public class Axis2SynapseController implements SynapseController {
     private void handleException(String msg) {
         log.error(msg);
         throw new SynapseException(msg);
-    }
-
-    public boolean isSynapseDebugMode() {
-        return synapseDebugMode;
-    }
-
-    public void setSynapseDebugMode(boolean synapseDebugMode) {
-        this.synapseDebugMode = synapseDebugMode;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/Axis2SynapseController.java
+++ b/modules/core/src/main/java/org/apache/synapse/Axis2SynapseController.java
@@ -108,6 +108,8 @@ public class Axis2SynapseController implements SynapseController {
 
     private TaskScheduler taskScheduler;
 
+    private boolean synapseDebugMode;
+
     /**
      * {@inheritDoc}
      *
@@ -503,6 +505,9 @@ public class Axis2SynapseController implements SynapseController {
 
         //we initialize xpath extensions here since synapse environment is available
         initXpathExtensions();
+
+        ((Axis2SynapseEnvironment) synapseEnvironment)
+                .setSynapseDebugMode(serverConfigurationInformation.isSynapseDebug());
 
         return synapseEnvironment;
     }
@@ -1010,5 +1015,13 @@ public class Axis2SynapseController implements SynapseController {
     private void handleException(String msg) {
         log.error(msg);
         throw new SynapseException(msg);
+    }
+
+    public boolean isSynapseDebugMode() {
+        return synapseDebugMode;
+    }
+
+    public void setSynapseDebugMode(boolean synapseDebugMode) {
+        this.synapseDebugMode = synapseDebugMode;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/ServerConfigurationInformation.java
+++ b/modules/core/src/main/java/org/apache/synapse/ServerConfigurationInformation.java
@@ -61,6 +61,8 @@ public class ServerConfigurationInformation {
     private String ipAddress;
     /* Deployment mode*/
     private String deploymentMode;
+    /* Synapse Debug mode */
+    private boolean synapseDebug;
 
     public ServerConfigurationInformation() {
         initServerHostAndIP();
@@ -231,8 +233,17 @@ public class ServerConfigurationInformation {
         }
     }
 
+    public boolean isSynapseDebug() {
+        return synapseDebug;
+    }
+
+    public void setSynapseDebug(boolean synapseDebug) {
+        this.synapseDebug = synapseDebug;
+    }
+
     public String toString() {
         StringBuffer sb = new StringBuffer();
+        sb.append("[ Synapse Debug Mode: ").append(synapseDebug).append(" ]");
         sb.append("[ Server Name : ").append(serverName).append(" ]");
         sb.append("[ Synapse Home : ").append(synapseHome).append(" ]");
         sb.append("[ Synapse XML : ").append(synapseXMLLocation).append(" ]");

--- a/modules/core/src/main/java/org/apache/synapse/ServerConfigurationInformationFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/ServerConfigurationInformationFactory.java
@@ -117,7 +117,11 @@ public class ServerConfigurationInformationFactory {
             information.setSynapseHome(args[2]);
             information.setSynapseXMLLocation(args[3]);
             information.setResolveRoot(args[4]);
-            information.setDeploymentMode(args[5]);
+            if (args[5].equalsIgnoreCase("synapseDebug")) {
+                information.setSynapseDebug(true);
+            } else {
+                information.setDeploymentMode(args[5]);
+            }
         } else if (args.length == 7) {
             information.setAxis2Xml(args[1]);
             information.setSynapseHome(args[2]);

--- a/modules/core/src/main/java/org/apache/synapse/core/SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/SynapseEnvironment.java
@@ -160,5 +160,11 @@ public interface SynapseEnvironment {
      */
     public Map<QName, SynapseXpathVariableResolver> getXpathVariableExtensions();
 
+    /**
+     * This is used to check if the server instance is started
+     * with synapseDebug mode flag
+     * @return true if the server is started with debug mode
+     */
+    public boolean isSynapseDebugMode();
 
 }

--- a/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
+++ b/modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2SynapseEnvironment.java
@@ -81,6 +81,8 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
     Map<QName, SynapseXpathVariableResolver> xpathVariableExtensions =
             new HashMap<QName, SynapseXpathVariableResolver>();
 
+    private boolean synapseDebugMode;
+
     public Axis2SynapseEnvironment(SynapseConfiguration synCfg) {
 
         int coreThreads = SynapseThreadPool.SYNAPSE_CORE_THREADS;
@@ -499,7 +501,10 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
          }
     }
 
-
+    @Override
+    public boolean isSynapseDebugMode() {
+        return this.synapseDebugMode;
+    }
 
     private void handleException(String message, Throwable e) {
         log.error(message, e);
@@ -544,5 +549,9 @@ public class Axis2SynapseEnvironment implements SynapseEnvironment {
             }
         }
         return null;
+    }
+
+    public void setSynapseDebugMode(boolean synapseDebugMode) {
+        this.synapseDebugMode = synapseDebugMode;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
+++ b/modules/core/src/main/java/org/apache/synapse/mediators/builtin/LogMediator.java
@@ -95,6 +95,9 @@ public class LogMediator extends AbstractMediator {
                 break;
             case CATEGORY_DEBUG :
                 synLog.auditDebug(getLogMessage(synCtx));
+                if (synCtx.getEnvironment().isSynapseDebugMode()) {
+                    synLog.auditLog(getLogMessage(synCtx));
+                }
                 break;
             case CATEGORY_WARN :
                 synLog.auditWarn(getLogMessage(synCtx));

--- a/modules/distribution/src/main/bin/synapse.bat
+++ b/modules/distribution/src/main/bin/synapse.bat
@@ -35,6 +35,7 @@ if ""%1""=="""" goto doneStart
 if ""%1""==""-sample"" goto SYNAPSESample
 if ""%1""==""-serverName"" goto serverName
 if ""%1""==""-xdebug"" goto xdebug
+if ""%1""==""-synapseDebug"" goto synapseDebug
 shift
 goto setupArgs
 
@@ -55,6 +56,11 @@ goto setupArgs
 shift
 set _SERVER_NAME=%1
 shift
+goto setupArgs
+
+:synapseDebug
+shift
+set _SNYPASE_DEBUG="synapseDebug"
 goto setupArgs
 
 :doneStart
@@ -111,7 +117,7 @@ rem
 rem Start the Wrapper
 rem
 :startup
-"%_WRAPPER_EXE%" -c %_WRAPPER_CONF% wrapper.app.parameter.5=%_SYNAPSE_XML% wrapper.app.parameter.8=%_SERVER_NAME% %_XDEBUG%
+"%_WRAPPER_EXE%" -c %_WRAPPER_CONF% wrapper.app.parameter.5=%_SYNAPSE_XML% wrapper.app.parameter.8=%_SERVER_NAME% wrapper.app.parameter.9=%_SNYPASE_DEBUG% %_XDEBUG%
 
 if not errorlevel 1 goto :eof
 pause

--- a/modules/distribution/src/main/bin/synapse.sh
+++ b/modules/distribution/src/main/bin/synapse.sh
@@ -156,7 +156,7 @@ elif [ "$1" = "-h" ]; then
     echo "  -xdebug            Start Synapse under JPDA debugger"
     echo "  -sample (number)   Start with sample Synapse configuration of given number"
     echo "  -serverName <name> Name of the Synapse server instance"
-    echo "  -synapseName       Start Synapse under debug mode"
+    echo "  -synapseDebug      Start Synapse under debug mode"
     shift
     exit 0
 

--- a/modules/distribution/src/main/bin/synapse.sh
+++ b/modules/distribution/src/main/bin/synapse.sh
@@ -146,12 +146,17 @@ if [ "$1" = "-xdebug" ]; then
     SERVER_NAME=$2
     shift 2 # -serverName and actual name
 
+  elif [ "$1" = "-synapseDebug" ]; then
+    SYNAPSE_DEBUG="synapseDebug"
+    shift
+
 elif [ "$1" = "-h" ]; then
     echo "Usage: synapse.sh ( commands ... )"
     echo "commands:"
     echo "  -xdebug            Start Synapse under JPDA debugger"
     echo "  -sample (number)   Start with sample Synapse configuration of given number"
     echo "  -serverName <name> Name of the Synapse server instance"
+    echo "  -synapseName       Start Synapse under debug mode"
     shift
     exit 0
 
@@ -185,4 +190,5 @@ $JAVA_HOME/bin/java -server -Xms512M -Xmx512M \
         $SYNAPSE_HOME \
         $SYNAPSE_XML \
         $SYNAPSE_HOME/repository \
-        $SERVER_NAME
+        $SERVER_NAME \
+        $SYNAPSE_DEBUG


### PR DESCRIPTION
Consider the below Proxy service in which I have configured the log-mediator to print logs only when the category is set to DEBUG. However, there is no way to start the server with log-mediator debug logs enabled. 

Only way to print the property values inside the log mediator is by configuring debug mode for the log -mediator class in the log4j.properties. But this is wrong because aforementioned configuration is there for the implementer of log-mediator but not for the synapse user.

```xml
 <proxy xmlns="http://ws.apache.org/ns/synapse"
       name="test"
       transports="http,https"
       statistics="disable"
       trace="disable"
       startOnLoad="true">
   <target>
      <inSequence>
         <log category="DEBUG">
            <property name="someproperty" value="somevalue"/>
         </log>
         <respond/>
      </inSequence>
   </target>
   <description/>
</proxy>
```
Above issue is fixed with this PR.

With this fix synapse users can start the server as follows which will enable debug mood for log-mediator. 

```
sh synapse.sh -synapseDebug
```

Following is a sample output of the log mediator. 

```
2020-03-04 21:01:02,663 [-] [PassThroughMessageProcessor-1]  INFO LogMediator To: /services/test, MessageID: urn:uuid:13cc5420-1282-456b-a0c0-fcfa6457c28e, Direction: request, someproperty = somevalue
```

