### PR TITLE
Remove CI badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![](https://github.com/apache/synapse/workflows/Synapse%20Daily%20Build/badge.svg)
-[![CI](https://github.com/apache/synapse/workflows/CI/badge.svg?branch=master)](https://github.com/apache/synapse/actions?query=workflow%3ACI)
 [![Build Status](https://builds.apache.org/job/Synapse%20-%20Trunk/badge/icon)](https://builds.apache.org/job/Synapse%20-%20Trunk/)
 
 # Synapse


### PR DESCRIPTION
CI build runs for a particular pull request. Failure or the success of the CI build does not reflect the build state of the entire source repository. So we need to remove that from the main readme file. 