### PR TITLE
Improve Message Forwarding Processor (MFP) to support HTTP status codes

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -412,9 +412,6 @@ public final class SynapseConstants {
 
     public static final String HTTP_SENDER_STATUSCODE = "transport.http.statusCode";
 
-    public static final String HTTP_INTERNAL_SERVER_ERROR = "500";
-    public static final String HTTP_BAD_REQUEST_ERROR = "400";
-
     // Fail-safe mode properties
     public static final String FAIL_SAFE_MODE_STATUS = "failsafe.mode.enable";
     public static final String FAIL_SAFE_MODE_ALL = "all";

--- a/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/SynapseConstants.java
@@ -412,6 +412,9 @@ public final class SynapseConstants {
 
     public static final String HTTP_SENDER_STATUSCODE = "transport.http.statusCode";
 
+    public static final String HTTP_INTERNAL_SERVER_ERROR = "500";
+    public static final String HTTP_BAD_REQUEST_ERROR = "400";
+
     // Fail-safe mode properties
     public static final String FAIL_SAFE_MODE_STATUS = "failsafe.mode.enable";
     public static final String FAIL_SAFE_MODE_ALL = "all";

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/MessageProcessorConsents.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/MessageProcessorConsents.java
@@ -35,4 +35,10 @@ public final class MessageProcessorConsents {
      */
     public static final String MAX_DELIVER_ATTEMPTS = "max.deliver.attempts";
 
+    /**
+     * HTTP status codes which are used for message processor retry implementation
+     */
+    public static final String HTTP_INTERNAL_SERVER_ERROR = "500";
+    public static final String HTTP_BAD_REQUEST_ERROR = "400";
+
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
@@ -287,12 +287,12 @@ public class ForwardingJob implements StatefulJob {
 
     private void handle400and500statusCodes(MessageContext outCtx) {
         if ((outCtx.getProperty(NhttpConstants.HTTP_SC) != null)) {
-            outCtx.setProperty(SynapseConstants.BLOCKING_CLIENT_ERROR, "true");
-
             String httpStatusCode =  outCtx.getProperty(NhttpConstants.HTTP_SC).toString();
             if (httpStatusCode.equals(SynapseConstants.HTTP_INTERNAL_SERVER_ERROR)) {
+                outCtx.setProperty(SynapseConstants.BLOCKING_CLIENT_ERROR, "true");
                 outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, SynapseConstants.HTTP_INTERNAL_SERVER_ERROR);
             } else if (httpStatusCode.equals(SynapseConstants.HTTP_BAD_REQUEST_ERROR)) {
+                outCtx.setProperty(SynapseConstants.BLOCKING_CLIENT_ERROR, "true");
                 outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, SynapseConstants.HTTP_BAD_REQUEST_ERROR);
             }
         }

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
@@ -288,12 +288,12 @@ public class ForwardingJob implements StatefulJob {
     private void handle400and500statusCodes(MessageContext outCtx) {
         if ((outCtx.getProperty(NhttpConstants.HTTP_SC) != null)) {
             String httpStatusCode =  outCtx.getProperty(NhttpConstants.HTTP_SC).toString();
-            if (httpStatusCode.equals(SynapseConstants.HTTP_INTERNAL_SERVER_ERROR)) {
+            if (httpStatusCode.equals(MessageProcessorConsents.HTTP_INTERNAL_SERVER_ERROR)) {
                 outCtx.setProperty(SynapseConstants.BLOCKING_CLIENT_ERROR, "true");
-                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, SynapseConstants.HTTP_INTERNAL_SERVER_ERROR);
-            } else if (httpStatusCode.equals(SynapseConstants.HTTP_BAD_REQUEST_ERROR)) {
+                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, MessageProcessorConsents.HTTP_INTERNAL_SERVER_ERROR);
+            } else if (httpStatusCode.equals(MessageProcessorConsents.HTTP_BAD_REQUEST_ERROR)) {
                 outCtx.setProperty(SynapseConstants.BLOCKING_CLIENT_ERROR, "true");
-                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, SynapseConstants.HTTP_BAD_REQUEST_ERROR);
+                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, MessageProcessorConsents.HTTP_BAD_REQUEST_ERROR);
             }
         }
     }

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
@@ -32,6 +32,7 @@ import org.apache.synapse.endpoints.AbstractEndpoint;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.message.processors.MessageProcessorConsents;
 import org.apache.synapse.message.store.MessageStore;
+import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -48,6 +49,10 @@ public class ForwardingJob implements StatefulJob {
 
     private static final Log log = LogFactory.getLog(ForwardingJob.class);
 
+    /**
+     * Includes HTTP status for which message processor should retry
+     */
+    private String[] retryHttpStatusCodes;
 
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
         JobDataMap jdm = jobExecutionContext.getMergedJobDataMap();
@@ -84,6 +89,11 @@ public class ForwardingJob implements StatefulJob {
 	        //Configuration to continue the message processor even without stopping the message processor
 	        // after maximum number of delivery
             isMaxDeliverAttemptDropEnabled = true;
+        }
+
+        if (parameters != null && parameters.get(ForwardingProcessorConstants.RETRY_HTTP_STATUS_CODES) != null) {
+            retryHttpStatusCodes = parameters
+                    .get(ForwardingProcessorConstants.RETRY_HTTP_STATUS_CODES).toString().split(",");
         }
 
         // WE do not try to process if the processor is inactive or
@@ -142,43 +152,47 @@ public class ForwardingJob implements StatefulJob {
                         try {
                             MessageContext outCtx = sender.send(ep, messageContext);
 
-                            if (outCtx != null && "true".equals(outCtx.
-                                    getProperty(SynapseConstants.BLOCKING_CLIENT_ERROR))) {
-                                // This Means an Error has occurred
+                            if (outCtx != null) {
+                                handle400and500statusCodes(outCtx);
 
-                                if (maxDeliverAttempts > 0) {
-                                    processor.incrementSendAttemptCount();
-                                }
-
-                                if (parameters != null &&
-                                        parameters.get(
-                                                ForwardingProcessorConstants.FAULT_SEQUENCE) != null) {
-
-                                    String seq = (String) parameters.get(
-                                            ForwardingProcessorConstants.FAULT_SEQUENCE);
-                                    Mediator mediator = outCtx.getSequence(seq);
-                                    if (mediator != null) {
-                                        mediator.mediate(outCtx);
-                                    } else {
-                                        log.warn("Can't Send the fault Message , Sequence " + seq +
-                                                " Does not Exist");
+                                if ("true".equals(outCtx.getProperty(SynapseConstants.BLOCKING_CLIENT_ERROR))) {
+                                    // This Means an Error has occurred
+                                    if (!retryForHttpStatusCodes(messageStore, processor, outCtx)) {
+                                        continue;
                                     }
 
-                                }
-
-                                if (maxDeliverAttempts > 0) {
-                                    if(processor.getSendAttemptCount() >= maxDeliverAttempts) {
-                                        deactivate(processor, messageContext, parameters);
+                                    if (maxDeliverAttempts > 0) {
+                                        processor.incrementSendAttemptCount();
                                     }
-                                }
-                                errorStop = true;
-                                continue;
 
-                            } else if (outCtx == null) {
-                                // This Means we have invoked an out only operation
-                                // remove the message and reset the count
-                                messageStore.poll();
-                                processor.resetSentAttemptCount();
+                                    if (parameters != null &&
+                                            parameters.get(
+                                                    ForwardingProcessorConstants.FAULT_SEQUENCE) != null) {
+
+                                        String seq = (String) parameters.get(
+                                                ForwardingProcessorConstants.FAULT_SEQUENCE);
+                                        Mediator mediator = outCtx.getSequence(seq);
+                                        if (mediator != null) {
+                                            mediator.mediate(outCtx);
+                                        } else {
+                                            log.warn("Can't Send the fault Message , Sequence " + seq +
+                                                             " Does not Exist");
+                                        }
+
+                                    }
+
+                                    if (maxDeliverAttempts > 0) {
+                                        if (processor.getSendAttemptCount() >= maxDeliverAttempts) {
+                                            deactivate(processor, messageContext, parameters);
+                                        }
+                                    }
+                                    errorStop = true;
+                                } else {
+                                    // This Means we have invoked an out only operation
+                                    // remove the message and reset the count
+                                    messageStore.poll();
+                                    processor.resetSentAttemptCount();
+                                }
                                 continue;
                             }
 
@@ -255,6 +269,35 @@ public class ForwardingJob implements StatefulJob {
         }
     }
 
+    private boolean retryForHttpStatusCodes(MessageStore messageStore, ScheduledMessageForwardingProcessor processor,
+                                            MessageContext outCtx) {
+        // No need to retry for application level failures
+        if (outCtx.getProperty(SynapseConstants.ERROR_MESSAGE) != null) {
+            String errorMsg = outCtx.getProperty(SynapseConstants.ERROR_MESSAGE).toString();
+            if (errorMsg.matches(".*[3-5]\\d\\d.*")) {
+                if (!isRetryHttpStatusCode(errorMsg)) {
+                    messageStore.poll();
+                    processor.resetSentAttemptCount();
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void handle400and500statusCodes(MessageContext outCtx) {
+        if ((outCtx.getProperty(NhttpConstants.HTTP_SC) != null)) {
+            outCtx.setProperty(SynapseConstants.BLOCKING_CLIENT_ERROR, "true");
+
+            String httpStatusCode =  outCtx.getProperty(NhttpConstants.HTTP_SC).toString();
+            if (httpStatusCode.equals(SynapseConstants.HTTP_INTERNAL_SERVER_ERROR)) {
+                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, SynapseConstants.HTTP_INTERNAL_SERVER_ERROR);
+            } else if (httpStatusCode.equals(SynapseConstants.HTTP_BAD_REQUEST_ERROR)) {
+                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, SynapseConstants.HTTP_BAD_REQUEST_ERROR);
+            }
+        }
+    }
+
     /**
      * Helper method to get a value of a parameters in the AxisConfiguration
      *
@@ -291,5 +334,17 @@ public class ForwardingJob implements StatefulJob {
                 }
             }
         }
+    }
+
+    private boolean isRetryHttpStatusCode(String message) {
+        if (retryHttpStatusCodes == null) {
+            return false;
+        }
+        for (String statsCode : retryHttpStatusCodes) {
+            if (message.contains(statsCode)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingProcessorConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingProcessorConstants.java
@@ -65,4 +65,8 @@ public final class ForwardingProcessorConstants {
      */
     public static final String MAX_DELIVER_DROP = "max.deliver.drop";
 
+    /**
+     * Used to determine for which HTTP status codes, message processor should retry
+     */
+    public static final String RETRY_HTTP_STATUS_CODES = "retry.http.status.codes";
 }


### PR DESCRIPTION
At the moment, current MFP implementation does not support retrying based on HTTP status codes. It only supports retrying for transport level failures but not for application level failures. As you know, in HTTP protocol, application level failures are distinguished using different status codes. In the case of MFP, it is important to be able to retry for 5xx server errors. But there also could be rare occasions in which retrying for 4xx and 3xx are useful. Especially when dealing with servers that do not follow HTTP protocol exactly as it is.

Therefore, I have improved MFP implementation to support retrying based on the returned HTTP status code as well. Say, a user wants to retry for HTTP status codes 500 and 504 but not for any other HTTP status code. In that case user can configure the MFP as below. Please note the parameter in bold font which I have introduced along with this feature. 

```xml
<messageProcessor xmlns="http://ws.apache.org/ns/synapse"     
 class="org.apache.synapse.message.processors.forward.ScheduledMessageForwardingProcessor"
                  name="Processor2"
                  messageStore="JMSMS">
   <parameter name="max.delivery.attempts">4</parameter>
   <parameter name="message.processor.reply.sequence">replySequence</parameter>
   <parameter name="interval">1000</parameter>
   <parameter name="retry.http.status.codes">500, 504</parameter>
</messageProcessor>
```
Please not that the above parameter does not come to effect in case of out-only. Once this is merged, I am planning to send another PR for the required documentation changes. 