### PR TITLE
Add windows runner to workflow

### DIFF
--- a/.github/workflows/build_cron.yml
+++ b/.github/workflows/build_cron.yml
@@ -8,9 +8,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest]
         java: [ 8 ]
 
     steps:


### PR DESCRIPTION
This will run the daily build on latest windows apart from running it on latest linux os.