### PR TITLE
Fix the typo in the class name

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processors/MessageProcessorConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/MessageProcessorConstants.java
@@ -18,7 +18,7 @@
  */
 package org.apache.synapse.message.processors;
 
-public final class MessageProcessorConsents {
+public final class MessageProcessorConstants {
 
     public static final String MESSAGE_STORE = "message.store";
     public static final String PARAMETERS = "parameters";

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/ScheduledMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/ScheduledMessageProcessor.java
@@ -82,9 +82,9 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
 
         JobBuilder jobBuilder = getJobBuilder();
         JobDataMap jobDataMap = getJobDataMap();
-        jobDataMap.put(MessageProcessorConsents.MESSAGE_STORE,
-                configuration.getMessageStore(messageStore));
-        jobDataMap.put(MessageProcessorConsents.PARAMETERS, parameters);
+        jobDataMap.put(MessageProcessorConstants.MESSAGE_STORE,
+                       configuration.getMessageStore(messageStore));
+        jobDataMap.put(MessageProcessorConstants.PARAMETERS, parameters);
 
         JobDetail jobDetail = jobBuilder.usingJobData(jobDataMap).build();
 
@@ -117,18 +117,18 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
     public void setParameters(Map<String, Object> parameters) {
         super.setParameters(parameters);
         if (parameters != null && !parameters.isEmpty()) {
-            Object o = parameters.get(MessageProcessorConsents.CRON_EXPRESSION);
+            Object o = parameters.get(MessageProcessorConstants.CRON_EXPRESSION);
             if (o != null) {
                 cronExpression = o.toString();
             }
 
-            o = parameters.get(MessageProcessorConsents.INTERVAL);
+            o = parameters.get(MessageProcessorConstants.INTERVAL);
             if (o != null) {
                 interval = Integer.parseInt(o.toString());
             }
 
 
-            o = parameters.get(MessageProcessorConsents.QUARTZ_CONF);
+            o = parameters.get(MessageProcessorConstants.QUARTZ_CONF);
             if (o != null) {
                 quartzConfig = o.toString();
             }

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
@@ -30,7 +30,7 @@ import org.apache.synapse.core.axis2.Axis2BlockingClient;
 import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.endpoints.AbstractEndpoint;
 import org.apache.synapse.endpoints.Endpoint;
-import org.apache.synapse.message.processors.MessageProcessorConsents;
+import org.apache.synapse.message.processors.MessageProcessorConstants;
 import org.apache.synapse.message.store.MessageStore;
 import org.apache.synapse.transport.nhttp.NhttpConstants;
 import org.quartz.JobDataMap;
@@ -58,9 +58,9 @@ public class ForwardingJob implements StatefulJob {
         JobDataMap jdm = jobExecutionContext.getMergedJobDataMap();
 
         //Get the Global Objects from DataMap
-        MessageStore messageStore = (MessageStore) jdm.get(MessageProcessorConsents.MESSAGE_STORE);
+        MessageStore messageStore = (MessageStore) jdm.get(MessageProcessorConstants.MESSAGE_STORE);
         Map<String, Object> parameters = (Map<String, Object>) jdm.get(
-                MessageProcessorConsents.PARAMETERS);
+                MessageProcessorConstants.PARAMETERS);
         Axis2BlockingClient sender = (Axis2BlockingClient) jdm.get(
                 ScheduledMessageForwardingProcessor.BLOCKING_SENDER);
         ScheduledMessageForwardingProcessor processor = (ScheduledMessageForwardingProcessor) jdm.get(
@@ -72,7 +72,7 @@ public class ForwardingJob implements StatefulJob {
 
         String mdaParam = null;
         if (parameters != null) {
-            mdaParam = (String) parameters.get(MessageProcessorConsents.MAX_DELIVER_ATTEMPTS);
+            mdaParam = (String) parameters.get(MessageProcessorConstants.MAX_DELIVER_ATTEMPTS);
         }
 
         if (mdaParam != null) {
@@ -288,12 +288,12 @@ public class ForwardingJob implements StatefulJob {
     private void handle400and500statusCodes(MessageContext outCtx) {
         if ((outCtx.getProperty(NhttpConstants.HTTP_SC) != null)) {
             String httpStatusCode =  outCtx.getProperty(NhttpConstants.HTTP_SC).toString();
-            if (httpStatusCode.equals(MessageProcessorConsents.HTTP_INTERNAL_SERVER_ERROR)) {
+            if (httpStatusCode.equals(MessageProcessorConstants.HTTP_INTERNAL_SERVER_ERROR)) {
                 outCtx.setProperty(SynapseConstants.BLOCKING_CLIENT_ERROR, "true");
-                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, MessageProcessorConsents.HTTP_INTERNAL_SERVER_ERROR);
-            } else if (httpStatusCode.equals(MessageProcessorConsents.HTTP_BAD_REQUEST_ERROR)) {
+                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, MessageProcessorConstants.HTTP_INTERNAL_SERVER_ERROR);
+            } else if (httpStatusCode.equals(MessageProcessorConstants.HTTP_BAD_REQUEST_ERROR)) {
                 outCtx.setProperty(SynapseConstants.BLOCKING_CLIENT_ERROR, "true");
-                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, MessageProcessorConsents.HTTP_BAD_REQUEST_ERROR);
+                outCtx.setProperty(SynapseConstants.ERROR_MESSAGE, MessageProcessorConstants.HTTP_BAD_REQUEST_ERROR);
             }
         }
     }

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/resequence/ResequencingJob.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/resequence/ResequencingJob.java
@@ -23,7 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
-import org.apache.synapse.message.processors.MessageProcessorConsents;
+import org.apache.synapse.message.processors.MessageProcessorConstants;
 import org.apache.synapse.message.processors.ScheduledMessageProcessor;
 import org.apache.synapse.message.store.MessageStore;
 import org.apache.synapse.util.xpath.SynapseXPath;
@@ -58,11 +58,11 @@ public class ResequencingJob implements Job {
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
 
         final JobDataMap jdm = jobExecutionContext.getMergedJobDataMap();
-        final MessageStore messageStore = (MessageStore) jdm.get(MessageProcessorConsents.MESSAGE_STORE);
+        final MessageStore messageStore = (MessageStore) jdm.get(MessageProcessorConstants.MESSAGE_STORE);
         final ResequencingProcessor processor = (ResequencingProcessor) jdm.get(
                 ScheduledMessageProcessor.PROCESSOR_INSTANCE);
 
-        final Map<String, Object> parameters = (Map<String, Object>) jdm.get(MessageProcessorConsents.PARAMETERS);
+        final Map<String, Object> parameters = (Map<String, Object>) jdm.get(MessageProcessorConstants.PARAMETERS);
         final String sequence = (String) parameters.get(ResequencingProcessor.NEXT_SEQUENCE);
 
         SynapseXPath seqNoxPath = null;

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/sampler/SamplingJob.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/sampler/SamplingJob.java
@@ -24,7 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
-import org.apache.synapse.message.processors.MessageProcessorConsents;
+import org.apache.synapse.message.processors.MessageProcessorConstants;
 import org.apache.synapse.message.processors.ScheduledMessageProcessor;
 import org.apache.synapse.message.store.MessageStore;
 import org.quartz.Job;
@@ -32,10 +32,8 @@ import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.locks.Lock;
 
 public class SamplingJob implements Job {
     private static Log log = LogFactory.getLog(SamplingJob.class);
@@ -44,10 +42,10 @@ public class SamplingJob implements Job {
         JobDataMap jdm = jobExecutionContext.getMergedJobDataMap();
 
         final MessageStore messageStore = (MessageStore) jdm.get(
-                MessageProcessorConsents.MESSAGE_STORE);
+                MessageProcessorConstants.MESSAGE_STORE);
 
         Map<String, Object> parameters = (Map<String, Object>) jdm.get(
-                MessageProcessorConsents.PARAMETERS);
+                MessageProcessorConstants.PARAMETERS);
         SamplingProcessor processor = (SamplingProcessor)
                 jdm.get(ScheduledMessageProcessor.PROCESSOR_INSTANCE);
 


### PR DESCRIPTION
Hi All,

I have fixed the typo in the class as follows,

`MessageProcessorConsents` -> `MessageProcessorConstants`