### PR TITLE
Add mac-os runner for the daily build

### DIFF
--- a/.github/workflows/build_cron.yml
+++ b/.github/workflows/build_cron.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         java: [ 8 ]
 
     steps:


### PR DESCRIPTION
At the moment daily build only runs on ubuntu and windows. This PR adds mac-os to the list.