### PR TITLE
Add Java 7 to build matrix

### DIFF
--- a/.github/workflows/build_cron.yml
+++ b/.github/workflows/build_cron.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        java: [ 8 ]
+        java: [7, 8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Add the moment workflow configured to do daily builds only runs on java 8. This PR change the workflow to include java 7 along with java 8.