### PR TITLE
Add different OSs and JDKs

### DIFF
--- a/.github/workflows/build_pull.yml
+++ b/.github/workflows/build_pull.yml
@@ -10,10 +10,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [ 8 ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        java: [7, 8]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
At the moment the build that runs for each PR only runs on ubuntu and Java 8. With this PR I have added windows and mac to the build along with Java 7.