### PR TITLE
Fix the issue of not invoking fault-sequence

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingJob.java
@@ -344,6 +344,7 @@ public class ForwardingJob implements StatefulJob {
     }
 
     private void handleOutOnlyError(MessageContext inMsgCtx) {
+        sendItToFaultSequence(inMsgCtx);
         if (maxDeliverAttempts > 0) {
             processor.incrementSendAttemptCount();
             handleMaxDeliveryAttempts(inMsgCtx);


### PR DESCRIPTION
At the moment, when there is a failure in Message Processor (i.e. Connection refused) fault sequence is not invoked in `OUT_ONLY` scenario. This issue is fixed with this PR.