### PR TITLE
Add consume one message at a time feature

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingProcessorConstants.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/forward/ForwardingProcessorConstants.java
@@ -74,4 +74,9 @@ public final class ForwardingProcessorConstants {
      * Used to determine the retry interval between retries
      */
     public static final String RETRY_INTERVAL = "retry.interval";
+
+    /**
+     * Used to determine if all the messages should be consumed per iteration
+     */
+    public static final String CONSUME_ALL = "consume.all";
 }


### PR DESCRIPTION
Current behavior of the Message Forwarding Processor is to consume all the messages at once. For instance, say, the Message Forwarding Processor is configured to run every 10 seconds and the Message store is filled with 5 messages within the 10 second gap. In such a situation, Message Forwarding Processor consumes all 5 messages and try to send it to back-end as fast as possible. I think this behavior is not optimal. The purpose of Message Forwarding Processor it to send messages to the back-end in a controlled rate. So that the back-end server can handle the load. IMO, ideal behavior should be to consume one message at a time and try to send it to the back-end as per the configured interval. 

I have implemented this feature by introducing the below configuration to Message Processor.

```xml
<parameter name="consume.all">false</parameter>
```

Default behavior is to consume all the messages at once. When the value of `consume.all`, is set to `false`. Message processor would only consume one message per each trigger.

**Please Note** that I have done a small refactoring along with this change by extracting out some code to `setRetryInterval()` function.