### PR TITLE
Fix the build

### DIFF
--- a/.github/workflows/build_cron.yml
+++ b/.github/workflows/build_cron.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v2
         
-      - name: Setup java 8
+      - name: Setup java 7
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 7
 
       - name: Cache maven artifacts
         uses: actions/cache@v2

--- a/.github/workflows/build_pull.yml
+++ b/.github/workflows/build_pull.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        java: [7, 8]
+        java: [7]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
At the moment both daily build and the PR builds are failing due to a SSL issue. This issue is only seen when the build is run with Java 8 which is provided by setup-java github action. I am further looking into this issue. In the mean time I have removed Java 8 build.

Please note that  the same issue is not there when building with Java 8. So this seems be an issue specific to the github environment. 