### PR TITLE
Improving how Target Endpoint is Associated with Message Forwarding Processor

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MessageProcessorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MessageProcessorFactory.java
@@ -93,11 +93,11 @@ public class MessageProcessorFactory {
         }
 
         if (FORWARDING_PROCESSOR.equals(clssAtt.getAttributeValue())) {
-            OMAttribute targetSequenceAtt = elem.getAttribute(TARGET_ENDPOINT_Q);
+            OMAttribute targetEndpointAtt = elem.getAttribute(TARGET_ENDPOINT_Q);
 
-            if (targetSequenceAtt != null) {
+            if (targetEndpointAtt != null) {
                 assert processor != null;
-                processor.setTargetEndpoint(targetSequenceAtt.getAttributeValue());
+                processor.setTargetEndpoint(targetEndpointAtt.getAttributeValue());
             } else {
                 // This validation is commented due to backward compatibility
                 // handleException("Can't create Message processor without a target endpoint ");

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MessageProcessorFactory.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MessageProcessorFactory.java
@@ -54,8 +54,12 @@ public class MessageProcessorFactory {
                                                       "parameter");
     public static final QName MESSAGE_STORE_Q = new QName(XMLConfigConstants.NULL_NAMESPACE,
                                                           "messageStore");
+    public static final QName TARGET_ENDPOINT_Q =
+            new QName(XMLConfigConstants.NULL_NAMESPACE, "targetEndpoint");
     private static final QName DESCRIPTION_Q
             = new QName(SynapseConstants.SYNAPSE_NAMESPACE, "description");
+    public static final String FORWARDING_PROCESSOR =
+            "org.apache.synapse.message.processors.forward.ScheduledMessageForwardingProcessor";
 
 
     /**
@@ -86,6 +90,18 @@ public class MessageProcessorFactory {
             processor.setName(nameAtt.getAttributeValue());
         } else {
             handleException("Can't create Message processor without a name ");
+        }
+
+        if (FORWARDING_PROCESSOR.equals(clssAtt.getAttributeValue())) {
+            OMAttribute targetSequenceAtt = elem.getAttribute(TARGET_ENDPOINT_Q);
+
+            if (targetSequenceAtt != null) {
+                assert processor != null;
+                processor.setTargetEndpoint(targetSequenceAtt.getAttributeValue());
+            } else {
+                // This validation is commented due to backward compatibility
+                // handleException("Can't create Message processor without a target endpoint ");
+            }
         }
 
         OMAttribute storeAtt = elem.getAttribute(MESSAGE_STORE_Q);

--- a/modules/core/src/main/java/org/apache/synapse/config/xml/MessageProcessorSerializer.java
+++ b/modules/core/src/main/java/org/apache/synapse/config/xml/MessageProcessorSerializer.java
@@ -49,6 +49,8 @@ public class MessageProcessorSerializer {
 
     private static final Log log = LogFactory.getLog(MessageProcessorSerializer.class);
 
+    public static final String FORWARDING_PROCESSOR =
+            "org.apache.synapse.message.processors.forward.ScheduledMessageForwardingProcessor";
     protected static final OMFactory fac = OMAbstractFactory.getOMFactory();
     protected static final OMNamespace synNS = SynapseConstants.SYNAPSE_OMNAMESPACE;
     protected static final OMNamespace nullNS = fac.createOMNamespace(
@@ -76,6 +78,16 @@ public class MessageProcessorSerializer {
             processorElem.addAttribute(fac.createOMAttribute("name", nullNS, processor.getName()));
         } else {
             handleException("Message store Name not specified");
+        }
+
+        if (FORWARDING_PROCESSOR.equals(processor.getClass().getName())) {
+            if (processor.getTargetEndpoint() != null) {
+                processorElem.addAttribute(
+                        fac.createOMAttribute("targetEndpoint", nullNS, processor.getTargetEndpoint()));
+            } else {
+                // This validation is removed to support backward compatibility
+                // handleException("Target Endpoint not specified");
+            }
         }
 
         if (processor.getMessageStoreName() != null) {

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/AbstractMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/AbstractMessageProcessor.java
@@ -47,6 +47,10 @@ public abstract class AbstractMessageProcessor implements MessageProcessor {
 
     protected String fileName;
 
+    /** This attribute is only need for forwarding message processor. However, it here because
+     * then we don't need to implement this in sampling processor with nothing */
+    protected String targetEndpoint;
+
     protected SynapseConfiguration configuration;
 
     protected enum State {
@@ -116,5 +120,13 @@ public abstract class AbstractMessageProcessor implements MessageProcessor {
 
     public String getFileName() {
         return fileName;
+    }
+
+    public void setTargetEndpoint(String targetEndpoint) {
+        this.targetEndpoint = targetEndpoint;
+    }
+
+    public String getTargetEndpoint() {
+        return targetEndpoint;
     }
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/MessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/MessageProcessor.java
@@ -85,4 +85,17 @@ public interface MessageProcessor extends ManagedLifecycle , Nameable , SynapseA
      * @return Name of the file where this artifact is defined
      */
     public String getFileName();
+
+    /**
+     * This method set the target endpoint associated with the message processor. Without a target endpoint
+     * a message processor could not operated successfully.
+     * @param targetEndpoint is the name of the associated endpoint
+     */
+    void setTargetEndpoint(String targetEndpoint);
+
+    /**
+     * This method is used to retrieve the associated target endpoint name of the message processor.
+     * @return The name of the endpoint
+     */
+    String getTargetEndpoint();
 }

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/MessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/MessageProcessor.java
@@ -87,8 +87,8 @@ public interface MessageProcessor extends ManagedLifecycle , Nameable , SynapseA
     public String getFileName();
 
     /**
-     * This method set the target endpoint associated with the message processor. Without a target endpoint
-     * a message processor could not operated successfully.
+     * This method set the target-endpoint associated with the Message Processor. Target-endpoint is a required
+     * parameter for Message Forwarding Processor but optional for Sampling Processor.
      * @param targetEndpoint is the name of the associated endpoint
      */
     void setTargetEndpoint(String targetEndpoint);

--- a/modules/core/src/main/java/org/apache/synapse/message/processors/ScheduledMessageProcessor.java
+++ b/modules/core/src/main/java/org/apache/synapse/message/processors/ScheduledMessageProcessor.java
@@ -21,6 +21,7 @@ package org.apache.synapse.message.processors;
 
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.core.SynapseEnvironment;
+import org.apache.synapse.message.processors.forward.ForwardingProcessorConstants;
 import org.quartz.*;
 import org.quartz.impl.StdSchedulerFactory;
 
@@ -84,6 +85,7 @@ public abstract class ScheduledMessageProcessor extends AbstractMessageProcessor
         JobDataMap jobDataMap = getJobDataMap();
         jobDataMap.put(MessageProcessorConstants.MESSAGE_STORE,
                        configuration.getMessageStore(messageStore));
+        jobDataMap.put(ForwardingProcessorConstants.TARGET_ENDPOINT, getTargetEndpoint());
         jobDataMap.put(MessageProcessorConstants.PARAMETERS, parameters);
 
         JobDetail jobDetail = jobBuilder.usingJobData(jobDataMap).build();


### PR DESCRIPTION
Now the target endpoint associated with Message Forwarding Processor can be given as an attribute of the Message Forwarding Processor config as below.

```xml
<messageProcessor class="org.apache.synapse.message.processors.forward.ScheduledMessageForwardingProcessor" name="ScheduledProcessor" messageStore="MyStore" targetEndpoint="StockQuoteServiceEp">
      <parameter name="interval">10000</parameter>
      <parameter name="max.deliver.attempts">3</parameter>
      <parameter name="max.deliver.drop">true</parameter>
      <parameter name="retry.http.status.codes">500, 504</parameter>
      <parameter name="retry.interval">1000</parameter>
      <parameter name="consume.all">false</parameter>
   </messageProcessor>
```

Therefore we no longer require the below property to configure Message Forwarding Processor. 

```xml
<property name="target.endpoint" value="StockQuoteServiceEp" />
```

However, to maintain backward compatibility both configurations are allowed. But going forward we need to remove this property support.

For more details please check the mail thread [1] in synapse dev.

[1] Improving how Target Endpoint is Associated with Message Forwarding Processor