### PR TITLE
Bump JDK version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1086,7 +1086,7 @@
         <!-- The Java version used to build Synapse. This property is used in the configuration
              of the maven-compiler-plugin as well as certain ant tasks executed using
              maven-antrun-plugin. -->
-        <java.version>1.6</java.version>
+        <java.version>1.7</java.version>
 
 	<synapse.version>${project.version}</synapse.version>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Bump deprecated JDK version (1.6) in root pom.xml to 1.7


### Why are the changes needed?
Update `java.version` field in pom.xml file


### Does this PR introduce _any_ user-facing change?
N/A


### How was this patch tested?
On JDK 1.7, Ubuntu 20.04 testing environment