### PR TITLE
Add Gitpod integration to project

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,3 @@
+FROM gitpod/workspace-full
+
+RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh              && sdk install java 8.0.265-open"

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,3 +1,3 @@
 FROM gitpod/workspace-full
 
-RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh              && sdk install java 8.0.265-open"
+RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && sdk install java 8.0.265-open && sdk install ant"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+
+tasks:
+  - init: mvn clean install
+
+image:
+  file: .gitpod.Dockerfile

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,3 +4,7 @@ tasks:
 
 image:
   file: .gitpod.Dockerfile
+
+vscode:
+  extensions:
+    - vscjava.vscode-java-pack

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![](https://github.com/apache/synapse/workflows/Synapse%20Daily%20Build/badge.svg)
 
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/apache/synapse)
+
 # Synapse
 Apache Synapse is a lightweight and high-performance Enterprise Service Bus (ESB). Powered by a fast and asynchronous mediation engine, Apache Synapse provides exceptional support for XML, Web Services and REST. In addition to XML and SOAP, 
 Apache Synapse supports several other content interchange formats, such as plain text, binary, Hessian and JSON. The wide range of transport adapters available for Synapse, enables it to communicate over many application and transport layer protocols. As of now, Apache Synapse supports HTTP/S, Mail (POP3, IMAP, SMTP), JMS, TCP, UDP, VFS, SMS, XMPP and FIX.


### PR DESCRIPTION
### Purpose
Add Gitpod integration to Apache Synapse project. 
Gitpod enables development to be done on a cloud VS Code IDE with access to a full Linux terminal.

![image](https://user-images.githubusercontent.com/24616975/158542999-babb1f53-0f28-4729-8b88-391c2bdc2dc6.png)

### Approach
The config files (gitpod.yml and gitpod.Dockerfile) were added 

### Automation Tests
- _Unit tests_
N/A

- _Integration tests_
N/A

### Test environment - Gitpod environment
- Java version 1.8.0_265
- Ubuntu 20.04

### Learning
A Notion document detailing related documentation can be found [here](https://typical-reading-1a7.notion.site/Gitpod-docs-801b93b7857140d8942d03e82c071d09).
