### PR TITLE
Add environment variable injection for LoadBalance endpoints

### DIFF
--- a/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/LoadBalanceEndpointSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/LoadBalanceEndpointSerializationTest.java
@@ -54,4 +54,36 @@ public class LoadBalanceEndpointSerializationTest extends AbstractTestCase {
 
         assertTrue(compare(serializedOut,inputElement));
     }
+
+    public void testLoadBalanceEndpointScenarioOneWithParameterInjection() throws Exception {
+        String inputXml = "<endpoint xmlns=\"http://ws.apache.org/ns/synapse\">" +
+                "<session type=\"simpleClientSession\"/>" +
+                "<loadbalance algorithm=\"org.apache.synapse.endpoints.algorithms.RoundRobin\">" +
+                "<endpoint>" +
+                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_MEMBER1\">" +
+                "<enableAddressing/>" +
+                "</address>" +
+                "</endpoint>" +
+                "<endpoint>" +
+                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_MEMBER2\">" +
+                "<enableAddressing/>" +
+                "</address>" +
+                "</endpoint>" +
+                "<endpoint>" +
+                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_MEMBER3\">" +
+                "<enableAddressing/>" +
+                "</address>" +
+                "</endpoint>" +
+                "</loadbalance>" +
+                "</endpoint>";
+
+
+        OMElement inputElement = createOMElement(inputXml);
+        Endpoint endpoint = LoadbalanceEndpointFactory.getEndpointFromElement(
+                inputElement,true,null);
+        OMElement serializedOut = LoadbalanceEndpointSerializer.getElementFromEndpoint(endpoint);
+
+        assertTrue(compare(serializedOut,inputElement));
+
+    }
 }

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/LoadBalanceEndpointSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/LoadBalanceEndpointSerializationTest.java
@@ -60,17 +60,17 @@ public class LoadBalanceEndpointSerializationTest extends AbstractTestCase {
                 "<session type=\"simpleClientSession\"/>" +
                 "<loadbalance algorithm=\"org.apache.synapse.endpoints.algorithms.RoundRobin\">" +
                 "<endpoint>" +
-                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_MEMBER1\">" +
+                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_ENDPOINT1\">" +
                 "<enableAddressing/>" +
                 "</address>" +
                 "</endpoint>" +
                 "<endpoint>" +
-                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_MEMBER2\">" +
+                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_ENDPOINT2\">" +
                 "<enableAddressing/>" +
                 "</address>" +
                 "</endpoint>" +
                 "<endpoint>" +
-                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_MEMBER3\">" +
+                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_ENDPOINT3\">" +
                 "<enableAddressing/>" +
                 "</address>" +
                 "</endpoint>" +

--- a/pom.xml
+++ b/pom.xml
@@ -283,8 +283,13 @@
                         <argLine>-Xms128m -Xmx256m</argLine>
                         <environmentVariables>
                             <SOAP_SERVICE_TEST>http://localhost:9000/services/MyService1</SOAP_SERVICE_TEST>
+
                             <WSDL_SERVICE_TEST_URI>file:src/test/resources/esbservice.wsdl</WSDL_SERVICE_TEST_URI>
                             <WSDL_SERVICE_TEST_PORT>esbserviceSOAP11port_http</WSDL_SERVICE_TEST_PORT>
+
+                            <LOAD_BALANCE_TEST_MEMBER1>http://localhost:9001/soap/LBService1</LOAD_BALANCE_TEST_MEMBER1>
+                            <LOAD_BALANCE_TEST_MEMBER2>http://localhost:9002/soap/LBService1</LOAD_BALANCE_TEST_MEMBER2>
+                            <LOAD_BALANCE_TEST_MEMBER3>http://localhost:9003/soap/LBService1</LOAD_BALANCE_TEST_MEMBER3>
                             <scope>test</scope>
                         </environmentVariables>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -287,9 +287,9 @@
                             <WSDL_SERVICE_TEST_URI>file:src/test/resources/esbservice.wsdl</WSDL_SERVICE_TEST_URI>
                             <WSDL_SERVICE_TEST_PORT>esbserviceSOAP11port_http</WSDL_SERVICE_TEST_PORT>
 
-                            <LOAD_BALANCE_TEST_MEMBER1>http://localhost:9001/soap/LBService1</LOAD_BALANCE_TEST_MEMBER1>
-                            <LOAD_BALANCE_TEST_MEMBER2>http://localhost:9002/soap/LBService1</LOAD_BALANCE_TEST_MEMBER2>
-                            <LOAD_BALANCE_TEST_MEMBER3>http://localhost:9003/soap/LBService1</LOAD_BALANCE_TEST_MEMBER3>
+                            <LOAD_BALANCE_TEST_ENDPOINT1>http://localhost:9001/soap/LBService1</LOAD_BALANCE_TEST_ENDPOINT1>
+                            <LOAD_BALANCE_TEST_ENDPOINT2>http://localhost:9002/soap/LBService1</LOAD_BALANCE_TEST_ENDPOINT2>
+                            <LOAD_BALANCE_TEST_ENDPOINT3>http://localhost:9003/soap/LBService1</LOAD_BALANCE_TEST_ENDPOINT3>
                             <scope>test</scope>
                         </environmentVariables>
                     </configuration>


### PR DESCRIPTION
## Purpose
Add environment variable injection capability to LoadBalance endpoints.

## Approach
Amended `AddressEndpointFactory` classes to extract environment variables via `System.getenv()` based on `$SYSTEM` prefix presence in the Synapse config XML URI elements.

## Automation tests
 - Unit tests 
   Covers related code written in abstract class `EndpointFactory`.
 - Integration tests
   N/A

## Related PRs
Builds on the work done on PR https://github.com/apache/synapse/pull/55

## Test environment
- Java version 1.8.0_141
- Ubuntu 20.04            