### PR TITLE
Add unit tests for environment variable injection in RecipientList endpoints

### DIFF
--- a/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/LoadBalanceEndpointSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/LoadBalanceEndpointSerializationTest.java
@@ -60,17 +60,17 @@ public class LoadBalanceEndpointSerializationTest extends AbstractTestCase {
                 "<session type=\"simpleClientSession\"/>" +
                 "<loadbalance algorithm=\"org.apache.synapse.endpoints.algorithms.RoundRobin\">" +
                 "<endpoint>" +
-                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_ENDPOINT1\">" +
+                "<address uri=\"$SYSTEM:SOAP_TEST_ENDPOINT1\">" +
                 "<enableAddressing/>" +
                 "</address>" +
                 "</endpoint>" +
                 "<endpoint>" +
-                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_ENDPOINT2\">" +
+                "<address uri=\"$SYSTEM:SOAP_TEST_ENDPOINT2\">" +
                 "<enableAddressing/>" +
                 "</address>" +
                 "</endpoint>" +
                 "<endpoint>" +
-                "<address uri=\"$SYSTEM:LOAD_BALANCE_TEST_ENDPOINT3\">" +
+                "<address uri=\"$SYSTEM:SOAP_TEST_ENDPOINT3\">" +
                 "<enableAddressing/>" +
                 "</address>" +
                 "</endpoint>" +

--- a/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/RecipientListEndpointSerializationTest.java
+++ b/modules/core/src/test/java/org/apache/synapse/config/xml/endpoints/RecipientListEndpointSerializationTest.java
@@ -54,6 +54,35 @@ public class RecipientListEndpointSerializationTest extends AbstractTestCase {
         assertTrue(compare(serializedOut, inputElement));
     }
 
+    public void testRecipientListEndpointScenarioOneWithParameterInjection() throws Exception {
+        String inputXml = "<endpoint xmlns=\"http://ws.apache.org/ns/synapse\">" +
+                "<recipientlist>" +
+                "<endpoint>" +
+                "<address uri=\"$SYSTEM:SOAP_TEST_ENDPOINT1\">" +
+                "<enableAddressing/>" +
+                "</address>" +
+                "</endpoint>" +
+                "<endpoint>" +
+                "<address uri=\"$SYSTEM:SOAP_TEST_ENDPOINT2\">" +
+                "<enableAddressing/>" +
+                "</address>" +
+                "</endpoint>" +
+                "<endpoint>" +
+                "<address uri=\"$SYSTEM:SOAP_TEST_ENDPOINT3\">" +
+                "<enableAddressing/>" +
+                "</address>" +
+                "</endpoint>" +
+                "</recipientlist>" +
+                "</endpoint>";
+
+        OMElement inputElement = createOMElement(inputXml);
+        Endpoint endpoint = RecipientListEndpointFactory.getEndpointFromElement(
+                inputElement,true,null);
+        OMElement serializedOut = RecipientListEndpointSerializer.getElementFromEndpoint(endpoint);
+
+        assertTrue(compare(serializedOut, inputElement));
+    }
+
     public void testRecipientListEndpointScenarioTwo()throws Exception {
         String inputXml = "<endpoint xmlns=\"http://ws.apache.org/ns/synapse\">" +
                 "<recipientlist>" +

--- a/pom.xml
+++ b/pom.xml
@@ -287,9 +287,9 @@
                             <WSDL_SERVICE_TEST_URI>file:src/test/resources/esbservice.wsdl</WSDL_SERVICE_TEST_URI>
                             <WSDL_SERVICE_TEST_PORT>esbserviceSOAP11port_http</WSDL_SERVICE_TEST_PORT>
 
-                            <LOAD_BALANCE_TEST_ENDPOINT1>http://localhost:9001/soap/LBService1</LOAD_BALANCE_TEST_ENDPOINT1>
-                            <LOAD_BALANCE_TEST_ENDPOINT2>http://localhost:9002/soap/LBService1</LOAD_BALANCE_TEST_ENDPOINT2>
-                            <LOAD_BALANCE_TEST_ENDPOINT3>http://localhost:9003/soap/LBService1</LOAD_BALANCE_TEST_ENDPOINT3>
+                            <SOAP_TEST_ENDPOINT1>http://localhost:9001/soap/LBService1</SOAP_TEST_ENDPOINT1>
+                            <SOAP_TEST_ENDPOINT2>http://localhost:9002/soap/LBService1</SOAP_TEST_ENDPOINT2>
+                            <SOAP_TEST_ENDPOINT3>http://localhost:9003/soap/LBService1</SOAP_TEST_ENDPOINT3>
                             <scope>test</scope>
                         </environmentVariables>
                     </configuration>


### PR DESCRIPTION
## Purpose
Add unit tests for variable injection capability in RecipientList endpoints.

## Approach
Added new unit test to `RecipientListEndpointSerializationTest` class. It builds on the work amending `AddressEndpointFactory` class to extract environment variables via `System.getenv()` based on `$SYSTEM` prefix presence in the Synapse config XML URI elements.

## Automation tests
 - Unit tests 
   Covers related code written in abstract class EndpointFactory.
 - Integration tests
   N/A

## Related PRs
Builds on the work done on PR https://github.com/apache/synapse/pull/55

## Test environment

- Java version 1.8.0_141
- Ubuntu 20.04
                   