### PR TITLE
Bump commons.cli.version from 1.2 to 1.9.0 & Update deprecated CommandLineParser implementation

### DIFF
--- a/modules/securevault/src/main/java/org/apache/synapse/securevault/tool/CipherTool.java
+++ b/modules/securevault/src/main/java/org/apache/synapse/securevault/tool/CipherTool.java
@@ -117,7 +117,7 @@ public final class CipherTool {
         Options options = getOptions();
 
         // create the command line parser
-        CommandLineParser parser = new GnuParser();
+        CommandLineParser parser = new DefaultParser();
 
         // parse the command line arguments
         try {

--- a/pom.xml
+++ b/pom.xml
@@ -1168,7 +1168,7 @@
         <commons.net.version>3.0.1</commons.net.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.io.version>2.7</commons.io.version>
-        <commons.cli.version>1.2</commons.cli.version>
+        <commons.cli.version>1.9.0</commons.cli.version>
         <commons.lang.version>2.6</commons.lang.version>
         <commons.codec.version>1.6</commons.codec.version>
 


### PR DESCRIPTION
## Purpose

* Bump commons.cli.version from 1.2 to 1.9.0
* Update deprecated GnuParse CommandLineParser implementation to DefaultParse implementation.