### PR TITLE
Update FaultHandler.java duplicate log entry. this is already availal…

### DIFF
--- a/modules/core/src/main/java/org/apache/synapse/FaultHandler.java
+++ b/modules/core/src/main/java/org/apache/synapse/FaultHandler.java
@@ -49,8 +49,7 @@ public abstract class FaultHandler {
             traceOrDebugWarn(traceOn, "FaultHandler executing impl: " + this.getClass().getName());
         }
 
-        try {
-            synCtx.getServiceLog().info("FaultHandler executing impl: " + this.getClass().getName());
+        try {            
             onFault(synCtx);
 
         } catch (SynapseException e) {


### PR DESCRIPTION
…e when tracerOrDebugOn is enabled

This changes is intended to remove duplicate log entry. 
- This is already available when tracerOrDebugOn flag is enabled.
- This entry flooding the logs files whenever this handler gets involved. for eg: "FaultHandler executing impl: "

## Purpose
log enhancement. It improves the logging. This is simply adding entry to log file whenever fault handler is executed. Since we already taken care with flag tracerOrDebugOn , we can remove this duplicate entry.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI. 
> Include a link to a Markdown file or Google doc if the feature 
> write-up is too long to paste here.

## Release note
> If applicable a brief description of the new feature or bug fix as it will appear in the release notes

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Related PRs
> List any other related PRs

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.                        