### PR TITLE
Fix create_repo execution order under apache-release profile

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -126,7 +126,7 @@
                 <executions>
                     <execution>
                         <id>create_repo</id>
-                        <phase>generate-test-resources</phase>
+                        <phase>process-test-resources</phase>
                         <configuration>
                             <tasks>
                                 <echo message="*** Creating a testing repository ***" />


### PR DESCRIPTION
The create_repo antrun execution and the test-library assembly executions were both bound to generate-test-resources. Their relative order depends on plugin declaration order in the merged pom, which the apache-release profile's assembly-plugin re-declaration flips — causing create_repo to run before the assemblies and fail copying zips that don't exist yet. Moving create_repo to process-test-resources removes the dependency on declaration order by relying on the lifecycle's fixed phase ordering instead.