### PR TITLE
Revert release plugin version bumps for cancelled 3.0.3 RC1 vote

### DIFF
--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/commons</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/commons</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/commons</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/commons/pom.xml
+++ b/modules/commons/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/commons</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/commons</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/commons</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -39,7 +39,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/core</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/core</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/core</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -39,7 +39,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/core</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/core</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/core</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/distribution</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/distribution</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/distribution</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/distribution</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/distribution</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/distribution</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <dependencies>

--- a/modules/documentation/pom.xml
+++ b/modules/documentation/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/documentation
         </developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/documentation</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/documentation/pom.xml
+++ b/modules/documentation/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/documentation
         </developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/documentation</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/experimental/pom.xml
+++ b/modules/experimental/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/experimental</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/experimental</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/experimental</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/experimental/pom.xml
+++ b/modules/experimental/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/experimental</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/experimental</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/experimental</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/extensions</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/extensions</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/extensions</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/extensions/pom.xml
+++ b/modules/extensions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/extensions</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/extensions</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/extensions</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/handler/pom.xml
+++ b/modules/handler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/handler</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/handler</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/handler</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/handler/pom.xml
+++ b/modules/handler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/handler</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/handler</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/handler</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/integration</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/integration</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/integration</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/migrator/pom.xml
+++ b/modules/migrator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -41,7 +41,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/migrator</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/migrator</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/migrator</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/migrator/pom.xml
+++ b/modules/migrator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -41,7 +41,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/migrator</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/migrator</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/migrator</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/packaging/package-archetype/pom.xml
+++ b/modules/packaging/package-archetype/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-archetype</artifactId>
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/packaging/package-archetype</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/packaging/package-archetype</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/packaging/package-archetype</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/packaging/package-archetype/pom.xml
+++ b/modules/packaging/package-archetype/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-archetype</artifactId>
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/packaging/package-archetype</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/packaging/package-archetype</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/packaging/package-archetype</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/packaging/package-skeleton/pom.xml
+++ b/modules/packaging/package-skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-skeleton</artifactId>
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/packaging/package-skeleton</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/packaging/package-skeleton</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/packaging/package-skeleton</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/modules/packaging/package-skeleton/pom.xml
+++ b/modules/packaging/package-skeleton/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-package-skeleton</artifactId>
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/packaging/package-skeleton</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/packaging/package-skeleton</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/packaging/package-skeleton</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <dependencies>

--- a/modules/patches/pom.xml
+++ b/modules/patches/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-patches</artifactId>
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/patches</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/patches</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/patches</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/patches/pom.xml
+++ b/modules/patches/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-patches</artifactId>
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/patches</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/patches</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/patches</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/samples/pom.xml
+++ b/modules/samples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/samples</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/samples</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/samples</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <profiles>

--- a/modules/samples/pom.xml
+++ b/modules/samples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/samples</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/samples</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/samples</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <profiles>

--- a/modules/securevault/pom.xml
+++ b/modules/securevault/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-securevault</artifactId>
@@ -35,7 +35,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/securevault</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/securevault</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/securevault</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/securevault/pom.xml
+++ b/modules/securevault/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <artifactId>synapse-securevault</artifactId>
@@ -35,7 +35,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/securevault</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/securevault</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/securevault</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/tasks/pom.xml
+++ b/modules/tasks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/tasks</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/tasks</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/tasks</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/tasks/pom.xml
+++ b/modules/tasks/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/tasks</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/tasks</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/tasks</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/nhttp</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/nhttp</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/nhttp</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/transports/core/nhttp/pom.xml
+++ b/modules/transports/core/nhttp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/nhttp</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/nhttp</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/nhttp</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/transports/core/pipe/pom.xml
+++ b/modules/transports/core/pipe/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/pipe</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/pipe</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/pipe</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/transports/core/pipe/pom.xml
+++ b/modules/transports/core/pipe/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/pipe</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/pipe</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/pipe</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/transports/core/vfs/pom.xml
+++ b/modules/transports/core/vfs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/vfs</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/vfs</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/vfs</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/transports/core/vfs/pom.xml
+++ b/modules/transports/core/vfs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/vfs</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/core/vfs</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/vfs</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/transports/optional/amqp/pom.xml
+++ b/modules/transports/optional/amqp/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -43,7 +43,7 @@ under the License.
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/optional/amqp</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/optional/amqp</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/optional/amqp</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/transports/optional/amqp/pom.xml
+++ b/modules/transports/optional/amqp/pom.xml
@@ -24,7 +24,7 @@ under the License.
 	<parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -43,7 +43,7 @@ under the License.
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/optional/amqp</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/optional/amqp</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/optional/amqp</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/transports/optional/fix/pom.xml
+++ b/modules/transports/optional/fix/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/optional/fix</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/optional/fix</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/optional/fix</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <build>

--- a/modules/transports/optional/fix/pom.xml
+++ b/modules/transports/optional/fix/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>synapse-transports</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/optional/fix</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports/optional/fix</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports/core/optional/fix</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <build>

--- a/modules/transports/pom.xml
+++ b/modules/transports/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <modules>

--- a/modules/transports/pom.xml
+++ b/modules/transports/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/transports</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/transports</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <modules>

--- a/modules/war/pom.xml
+++ b/modules/war/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/war</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/war</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/war</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <dependencies>

--- a/modules/war/pom.xml
+++ b/modules/war/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -37,7 +37,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/war</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/war</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/war</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <dependencies>

--- a/modules/xar-maven-plugin/pom.xml
+++ b/modules/xar-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.4-SNAPSHOT</version>
+        <version>3.0.3</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/xar-maven-plugin</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/xar-maven-plugin</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/xar-maven-plugin</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
     
     <dependencies>

--- a/modules/xar-maven-plugin/pom.xml
+++ b/modules/xar-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.synapse</groupId>
         <artifactId>Apache-Synapse</artifactId>
-        <version>3.0.3</version>
+        <version>3.0.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@
         <connection>scm:svn:http://svn.apache.org/repos/asf/synapse/trunk/java/modules/xar-maven-plugin</connection>
         <developerConnection>scm:svn:https://svn.apache.org/repos/asf/synapse/trunk/java/modules/xar-maven-plugin</developerConnection>
         <url>http://svn.apache.org/viewvc/synapse/trunk/java/modules/xar-maven-plugin</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
     
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.synapse</groupId>
     <artifactId>Apache-Synapse</artifactId>
-    <version>3.0.3</version>
+    <version>3.0.3-SNAPSHOT</version>
 
     <name>Apache Synapse</name>
     <description>Apache Synapse</description>
@@ -79,7 +79,7 @@
         <connection>scm:git:https://github.com/apache/synapse.git</connection>
         <developerConnection>scm:git:https://github.com/apache/synapse.git</developerConnection>
         <url>https://github.com/apache/synapse.git/</url>
-      <tag>Apache-Synapse-3.0.3</tag>
+      <tag>HEAD</tag>
   </scm>
 
     <organization>
@@ -1202,7 +1202,7 @@
     </modules>
 
     <properties>
-        <project.build.outputTimestamp>1785584917</project.build.outputTimestamp>
+        <project.build.outputTimestamp>1683222956</project.build.outputTimestamp>
         <!-- Sets the source encoding to UTF-8 -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -1210,7 +1210,7 @@
              of the maven-compiler-plugin as well as certain ant tasks executed using
              maven-antrun-plugin.-->
         <java.version>1.8</java.version>
-        <surefire.extra.argline />
+        <surefire.extra.argline></surefire.extra.argline>
 
 	    <synapse.version>${project.version}</synapse.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.apache.synapse</groupId>
     <artifactId>Apache-Synapse</artifactId>
-    <version>3.0.4-SNAPSHOT</version>
+    <version>3.0.3</version>
 
     <name>Apache Synapse</name>
     <description>Apache Synapse</description>
@@ -79,7 +79,7 @@
         <connection>scm:git:https://github.com/apache/synapse.git</connection>
         <developerConnection>scm:git:https://github.com/apache/synapse.git</developerConnection>
         <url>https://github.com/apache/synapse.git/</url>
-      <tag>HEAD</tag>
+      <tag>Apache-Synapse-3.0.3</tag>
   </scm>
 
     <organization>
@@ -1202,7 +1202,7 @@
     </modules>
 
     <properties>
-        <project.build.outputTimestamp>1785585306</project.build.outputTimestamp>
+        <project.build.outputTimestamp>1785584917</project.build.outputTimestamp>
         <!-- Sets the source encoding to UTF-8 -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
The 3.0.3 RC1 vote was cancelled: the sample server script
(modules/samples/src/main/scripts/axis2Server/axis2server.sh) passes
-Djava.endorsed.dirs, removed in JDK 9 (JEP 220), which prevents the JVM
from starting on JDK 17.

This reverts the two maven-release-plugin commits so master returns to
3.0.3-SNAPSHOT ahead of an RC2 respin.

  - Reverts e7fd093bf "prepare for next development iteration"
  - Reverts 91a7705ef "prepare release Apache-Synapse-3.0.3"

The Nexus staging repository (orgapachesynapse-1008) has been dropped and
the Apache-Synapse-3.0.3 tag removed. RC1 artifacts remain under
dist/dev/synapse/3.0.3/RC1/ for the record, following the 3.0.2 precedent.
